### PR TITLE
Fix MkDocs deploy workflow

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,14 +1,12 @@
-﻿name: Deploy MkDocs site
+name: Deploy MkDocs site
 
 on:
   push:
     branches:
-      - master  # Replace with your default branch if different
-    paths:
-      - '**.md'
-      - 'mkdocs.yml'
-      - '**.yml'
-      - '**.yaml'
+      - master
+
+permissions:
+  contents: write
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
- fix workflow formatting and remove BOM
- remove file path restrictions
- add permissions for gh-pages deployment

## Testing
- `mkdocs build -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d90659b4483298ca61408815b3ef9